### PR TITLE
Add SHA-256 hashes and version matching pattern for links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,17 @@
 
 ## 1.0.1 (2020-08-11)
 
-Fix:
+**Fix:**
 
   - [#13](https://github.com/unsplash/datasets/issues/13): AI landmarks were always empty.
   - Some landmark names were blank instead of NULL
   - Removed duplicated photo id `zV2-QjJqkI` in the Full Dataset
+
+**Lite dataset link:**
+
+  - Version link: [Version 1.0.1](https://unsplash.com/data/lite/1.0.1)
+  - Lite dataset links now follow the pattern `https://unsplash.com/data/lite/{version}` (starting at `1.0.1`)
+
+**Integrity checks (SHA-256):**
+  - Lite: `aa199951dd8756563f7ffef4abbc2d20c845bcff62241ae677af523728819d60`
+  - Full: `ee47f7542e5ef260e6b904046b4837532f420412a0e2c299dcecab55acd28d1f`


### PR DESCRIPTION
#### Overview

- Add SHA-256 hashes for integrity checks on Lite and Full datasets in the `CHANGELOG.md`
- Add links to download past lite datasets: `https://unsplash.com/data/lite/{version}`, with `version >= 1.0.1`
- These changes apply only from version `1.0.1` and forward
- Closes #24 
- Closes #23 
