### PR TITLE
Fix type for photo featured in create-tables.sql

### DIFF
--- a/how-to/psql/create_tables.sql
+++ b/how-to/psql/create_tables.sql
@@ -5,7 +5,7 @@ CREATE TABLE unsplash_photos (
   photo_url varchar(255),
   photo_image_url varchar(255),
   photo_submitted_at timestamp,
-  photo_featured varchar(255),
+  photo_featured boolean,
   photographer_username varchar(255),
   photographer_first_name varchar(255),
   photographer_last_name varchar(255),


### PR DESCRIPTION
#### Overview

- Changes `photos.featured` type in `psql` docs from `varchar(255)` to `boolean`
- Closes #25 