### PR TITLE
fix copy command for unsplash_colors

### DIFF
--- a/how-to/psql/load-data-client.sql
+++ b/how-to/psql/load-data-client.sql
@@ -2,4 +2,4 @@
 \COPY unsplash_keywords    FROM PROGRAM 'awk FNR-1 {path}/keywords.tsv* | cat'    WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);
 \COPY unsplash_collections FROM PROGRAM 'awk FNR-1 {path}/collections.tsv* | cat' WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);
 \COPY unsplash_conversions FROM PROGRAM 'awk FNR-1 {path}/conversions.tsv* | cat' WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);
-\COPY unsplash_conversions FROM PROGRAM 'awk FNR-1 {path}/colors.tsv* | cat' WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);
+\COPY unsplash_colors      FROM PROGRAM 'awk FNR-1 {path}/colors.tsv* | cat' WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);


### PR DESCRIPTION
#### Overview

The copy command for loading into the `unsplash_colors` table was incorrectly loading into the `unsplash_conversions` table