### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - Added 1.4M+ photos to the dataset (submitted up to `2025-01-01`)
   - Removed unavailable photos (that are removed from the platform)
   - The `conversions` period is now from `2024-01-01` to `2025-01-01`
+  - Added a minimum 40% confidence threshold for AI tags to appear in the dataset
 
 **Lite dataset link:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # CHANGELOG.md
 
+## 1.3.0 (2025-04-16)
+
+**Fix:**
+
+  - [#63](https://github.com/unsplash/datasets/issues/63): Longitude and latitude no longer swapped
+
+**New:**
+
+  - Added `user_suggestion_source` in the `keywords` dataset
+  - Added Unsplash topics in the `collections` dataset (check `collection_type`)
+
+**Data:**
+
+  - Added 1.4M+ photos to the dataset (submitted up to `2025-01-01`)
+  - Removed unavailable photos (that are removed from the platform)
+  - The `conversions` period is now from `2024-01-01` to `2025-01-01`
+
+**Lite dataset link:**
+
+  - Version link: [Version 1.3.0](https://unsplash.com/data/lite/1.3.0)
+
+**Integrity checks (SHA-256):**
+
+  - Lite: `c3c09225c4aee1c62cee1e7032db879d10b84407ed2953c2abf77dc6ca4c4ade`
+  - Full: `4ad1a3cb2b38529529f92bdc9ab4237a8b9b1153f1d615ff136581297ed5b58d`
+
 ## 1.2.2 (2024-02-09)
 
 **Data:**

--- a/DOCS.md
+++ b/DOCS.md
@@ -52,14 +52,16 @@ about how a keyword is connected to a photo and the conversions of the photo our
 | ai_service_1_confidence       | Confidence for the keyword from a 3rd party AI (0-100)|
 | ai_service_2_confidence       | Confidence for the keyword from another 3rd party AI (0-100)|
 | suggested_by_user             | Whether the keyword was added by a user (human) |
+| user_suggestion_source        | The type of user that suggested or set the keyword (photographer, admin or unknown) |
 
 ## 3 - collections.tsv
 
-*Note: A collection on Unsplash is a user created grouping of photos. These are similar to boards on Pinterest and can often group photos in complex and creative ways.*
+*Note: A collection on Unsplash is a user created grouping of photos. These are similar to boards on Pinterest and can often group photos in complex and creative ways. Another type of collection is topics. Topics are different content-specific photo feeds available
+on the website*
 
-The `collections.tsv` dataset has one row per photo-collection pair. Whenever a photo
-belongs to a collection created by a user, it will appear as one row. Each row describes
-when the photo was added to the collection and gives the title of the collection.
+The `collections.tsv` dataset has one row per photo-collection/topic pair. Whenever a photo
+belongs to a collection or a topic, it will appear as one row. Each row describes
+when the photo was added to the collection/topic and gives the title of the collection/topic.
 
 | Field                         | Description |
 |-------------------------------|-------------|
@@ -67,6 +69,7 @@ when the photo was added to the collection and gives the title of the collection
 | collection_id                 | ID of the Unsplash collection containing the photo |
 | collection_title              | Title of the collection containing the photo |
 | photo_collected_at            | Timestamp of when the photo was added to the collection |
+| collection_type               | Type of the collection (collection or topic) |
 
 ## 4 - conversions.tsv
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ![](https://unsplash.com/blog/content/images/2020/08/dataheader.jpg)
 
-The Unsplash Dataset is made up of over 350,000+ contributing global photographers and data sourced from hundreds of millions of searches across a nearly unlimited number of uses and contexts. Due to the breadth of intent and semantics contained within the Unsplash dataset, it enables new opportunities for research and learning.
+The Unsplash Dataset is made up of over 380,000+ contributing global photographers and data sourced from hundreds of millions of searches across a nearly unlimited number of uses and contexts. Due to the breadth of intent and semantics contained within the Unsplash dataset, it enables new opportunities for research and learning.
 
 The Unsplash Dataset is offered in two datasets:
 
 - the Lite dataset: available for commercial and noncommercial usage, containing 25k nature-themed Unsplash photos, 25k keywords, and 1M searches
-- the Full dataset: available for noncommercial usage, containing 6.8M+ high-quality Unsplash photos, 5M keywords, and over 250M searches
+- the Full dataset: available for noncommercial usage, containing 6.8M+ high-quality Unsplash photos, 1M keywords, and over 165M searches
 
 As the Unsplash library continues to grow, we’ll release updates to the dataset with new fields and new images, with each subsequent release being [semantically versioned](https://semver.org/).
 
@@ -21,11 +21,11 @@ For more on the Unsplash Dataset, see [our announcement](https://unsplash.com/bl
 
 The Lite dataset contains all of the same fields as the Full dataset, but is limited to ~25,000 photos. It can be used for both commercial and non-commercial usage, provided you abide by [the terms](https://github.com/unsplash/datasets/blob/master/TERMS.md).
 
-[⬇️ Download the Lite dataset](https://unsplash.com/data/lite/latest) [~700MB compressed, ~1.5GB raw]
+[⬇️ Download the Lite dataset](https://unsplash.com/data/lite/latest) [~700MB compressed, ~1GB raw]
 
 ### Full Dataset
 
-The Full dataset is available for non-commercial usage and all uses must abide by [the terms](https://github.com/unsplash/datasets/blob/master/TERMS.md). To access, please go to [unsplash.com/data](https://unsplash.com/data) and request access. The dataset weighs ~20 GB compressed (~50GB raw)).
+The Full dataset is available for non-commercial usage and all uses must abide by [the terms](https://github.com/unsplash/datasets/blob/master/TERMS.md). To access, please go to [unsplash.com/data](https://unsplash.com/data) and request access. The dataset weighs ~20 GB compressed (~80GB raw).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Unsplash Dataset is made up of over 350,000+ contributing global photographe
 The Unsplash Dataset is offered in two datasets:
 
 - the Lite dataset: available for commercial and noncommercial usage, containing 25k nature-themed Unsplash photos, 25k keywords, and 1M searches
-- the Full dataset: available for noncommercial usage, containing 5.4M+ high-quality Unsplash photos, 5M keywords, and over 250M searches
+- the Full dataset: available for noncommercial usage, containing 6.8M+ high-quality Unsplash photos, 5M keywords, and over 250M searches
 
 As the Unsplash library continues to grow, we’ll release updates to the dataset with new fields and new images, with each subsequent release being [semantically versioned](https://semver.org/).
 
@@ -45,7 +45,7 @@ We're making this data open and available with the hopes of enabling researchers
 
 We'd love to see what you create, whether that's a research paper, a machine learning model, a blog post, or just an interesting discovery in the data. Send us an email at [data@unsplash.com](mailto:data@unsplash.com).
 
-If you're using the dataset in a research paper, you can attribute the dataset as `Unsplash Lite Dataset 1.2.2` or `Unsplash Full Dataset 1.2.2` and link to the permalink [`unsplash.com/data`](https://unsplash.com/data).
+If you're using the dataset in a research paper, you can attribute the dataset as `Unsplash Lite Dataset 1.3.0` or `Unsplash Full Dataset 1.3.0` and link to the permalink [`unsplash.com/data`](https://unsplash.com/data).
 
 ----
 

--- a/how-to/psql/create_tables.sql
+++ b/how-to/psql/create_tables.sql
@@ -40,6 +40,7 @@ CREATE TABLE unsplash_keywords (
   ai_service_1_confidence float,
   ai_service_2_confidence float,
   suggested_by_user boolean,
+  user_suggestion_source varchar(255),
   PRIMARY KEY (photo_id, keyword)
 );
 
@@ -48,6 +49,7 @@ CREATE TABLE unsplash_collections (
   collection_id varchar(11),
   collection_title text,
   photo_collected_at timestamp,
+  collection_type varchar(255),
   PRIMARY KEY (photo_id, collection_id)
 );
 


### PR DESCRIPTION
#### Overview

The `1.3.0` release contains all the Unsplash photos submitted up to `2025-01-01`.
The conversions dataset contains all conversions on searches made in 2024.

We added Unsplash Topics and photos that belong to them as part of the `collections` dataset. You'll find a new `conversion_type` field indicating if the collection is a user collection or a topic.

We added information about the user type for the user suggested tags, when available.


#### Changelog

**Fix:**

  - [#63](https://github.com/unsplash/datasets/issues/63): Longitude and latitude no longer swapped

**New:**

  - Added `user_suggestion_source` in the `keywords` dataset
  - Added Unsplash topics in the `collections` dataset (check `collection_type`)

**Data:**

  - Added 1.4M+ photos to the dataset (submitted up to `2025-01-01`)
  - Removed unavailable photos (that are removed from the platform)
  - The `conversions` period is now from `2024-01-01` to `2025-01-01`
  - Added a minimum 40% confidence threshold for AI tags to appear in the dataset