### PR TITLE
fix: correct file extension glob pattern from .tsv to .csv

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1,10 +1,10 @@
 # Unsplash Dataset Documentation
 
-The Unsplash Dataset is composed of multiple TSV files:
+The Unsplash Dataset is composed of multiple CSV files:
 
-## 1 - photos.tsv
+## 1 - photos.csv
 
-The `photos.tsv` dataset has one row per photo. It contains properties of the photo, the name of the contributor, the image URL, and overall stats.
+The `photos.csv` dataset has one row per photo. It contains properties of the photo, the name of the contributor, the image URL, and overall stats.
 
 | Field                       | Description |
 |-----------------------------|-------------|
@@ -40,9 +40,9 @@ The `photos.tsv` dataset has one row per photo. It contains properties of the ph
 | ai_primary_landmark_confidence | Landmark confidence of the 3rd party AI |
 | blur_hash                      | [BlurHash](https://blurha.sh/) hash of the photo |
 
-## 2 - keywords.tsv
+## 2 - keywords.csv
 
-The `keywords.tsv` dataset has one row per photo-keyword pair. It contains data
+The `keywords.csv` dataset has one row per photo-keyword pair. It contains data
 about how a keyword is connected to a photo and the conversions of the photo our search engine for a particular keyword.
 
 | Field                         | Description |
@@ -54,12 +54,12 @@ about how a keyword is connected to a photo and the conversions of the photo our
 | suggested_by_user             | Whether the keyword was added by a user (human) |
 | user_suggestion_source        | The type of user that suggested or set the keyword (photographer, admin or unknown) |
 
-## 3 - collections.tsv
+## 3 - collections.csv
 
 *Note: A collection on Unsplash is a user created grouping of photos. These are similar to boards on Pinterest and can often group photos in complex and creative ways. Another type of collection is topics. Topics are different content-specific photo feeds available
 on the website*
 
-The `collections.tsv` dataset has one row per photo-collection/topic pair. Whenever a photo
+The `collections.csv` dataset has one row per photo-collection/topic pair. Whenever a photo
 belongs to a collection or a topic, it will appear as one row. Each row describes
 when the photo was added to the collection/topic and gives the title of the collection/topic.
 
@@ -71,11 +71,11 @@ when the photo was added to the collection/topic and gives the title of the coll
 | photo_collected_at            | Timestamp of when the photo was added to the collection |
 | collection_type               | Type of the collection (collection or topic) |
 
-## 4 - conversions.tsv
+## 4 - conversions.csv
 
 *Note: a conversion is currently defined as a user selecting an image to download it.*
 
-The `conversions.tsv` dataset has one row per search conversion. The dataset tells you which photo has been downloaded for a search, the country of origin, and an anonymous identifier to indiciate the unique users. The data goes back up to 1 year before the release of each version of the dataset.
+The `conversions.csv` dataset has one row per search conversion. The dataset tells you which photo has been downloaded for a search, the country of origin, and an anonymous identifier to indiciate the unique users. The data goes back up to 1 year before the release of each version of the dataset.
 
 | Field                         | Description |
 |-------------------------------|-------------|
@@ -86,11 +86,11 @@ The `conversions.tsv` dataset has one row per search conversion. The dataset tel
 | anonymous_user_id             | Anonymous user ID |
 | conversion_country            | Country code of the device geolocation |
 
-## 5 - colors.tsv
+## 5 - colors.csv
 
 *Note: The coverage and score data comes from a 3rd party AI*
 
-The `colors.tsv` dataset has one row per major color present in the photo. The dataset tells which colors are contained within a photo, their coverage as a percentage, and a score for how in focus the color is.
+The `colors.csv` dataset has one row per major color present in the photo. The dataset tells which colors are contained within a photo, their coverage as a percentage, and a score for how in focus the color is.
 
 | Field                     | Description |
 |---------------------------|-------------|

--- a/how-to/README.md
+++ b/how-to/README.md
@@ -1,6 +1,6 @@
 # How to load the dataset
 
-The dataset is contained in 4 separate TSV files.
+The dataset is contained in 5 separate CSV files.
 
 You can follow these examples to load the dataset in these common formats:
 

--- a/how-to/psql/load-data-client.sql
+++ b/how-to/psql/load-data-client.sql
@@ -1,5 +1,5 @@
-\COPY unsplash_photos      FROM PROGRAM 'awk FNR-1 {path}/photos.tsv* | cat'      WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);
-\COPY unsplash_keywords    FROM PROGRAM 'awk FNR-1 {path}/keywords.tsv* | cat'    WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);
-\COPY unsplash_collections FROM PROGRAM 'awk FNR-1 {path}/collections.tsv* | cat' WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);
-\COPY unsplash_conversions FROM PROGRAM 'awk FNR-1 {path}/conversions.tsv* | cat' WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);
-\COPY unsplash_colors      FROM PROGRAM 'awk FNR-1 {path}/colors.tsv* | cat' WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);
+\COPY unsplash_photos      FROM PROGRAM 'awk FNR-1 {path}/photos.csv* | cat'      WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);
+\COPY unsplash_keywords    FROM PROGRAM 'awk FNR-1 {path}/keywords.csv* | cat'    WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);
+\COPY unsplash_collections FROM PROGRAM 'awk FNR-1 {path}/collections.csv* | cat' WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);
+\COPY unsplash_conversions FROM PROGRAM 'awk FNR-1 {path}/conversions.csv* | cat' WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);
+\COPY unsplash_colors      FROM PROGRAM 'awk FNR-1 {path}/colors.csv* | cat' WITH ( FORMAT csv, DELIMITER E'\t', HEADER false);

--- a/how-to/psql/load-data-server.sql
+++ b/how-to/psql/load-data-server.sql
@@ -1,5 +1,5 @@
 COPY unsplash_photos
-FROM PROGRAM 'awk FNR-1 {path}/photos.tsv* | cat'
+FROM PROGRAM 'awk FNR-1 {path}/photos.csv* | cat'
 WITH (
   FORMAT csv,
   DELIMITER E'\t',
@@ -7,7 +7,7 @@ WITH (
 );
 
 COPY unsplash_keywords
-FROM PROGRAM 'awk FNR-1 {path}/keywords.tsv* | cat'
+FROM PROGRAM 'awk FNR-1 {path}/keywords.csv* | cat'
 WITH (
   FORMAT csv,
   DELIMITER E'\t',
@@ -15,7 +15,7 @@ WITH (
 );
 
 COPY unsplash_collections
-FROM PROGRAM 'awk FNR-1 {path}/collections.tsv* | cat'
+FROM PROGRAM 'awk FNR-1 {path}/collections.csv* | cat'
 WITH (
   FORMAT csv,
   DELIMITER E'\t',
@@ -23,7 +23,7 @@ WITH (
 );
 
 COPY unsplash_conversions
-FROM PROGRAM 'awk FNR-1 {path}/conversions.tsv* | cat'
+FROM PROGRAM 'awk FNR-1 {path}/conversions.csv* | cat'
 WITH (
   FORMAT csv,
   DELIMITER E'\t',
@@ -31,7 +31,7 @@ WITH (
 );
 
 COPY unsplash_colors
-FROM PROGRAM 'awk FNR-1 {path}/colors.tsv* | cat'
+FROM PROGRAM 'awk FNR-1 {path}/colors.csv* | cat'
 WITH (
   FORMAT csv,
   DELIMITER E'\t',

--- a/how-to/python/pandas.ipynb
+++ b/how-to/python/pandas.ipynb
@@ -3,8 +3,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "CtL5xVVyWuUK",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "CtL5xVVyWuUK"
       },
       "source": [
         "# Loading the Unsplash Research dataset in Pandas dataframes\n",
@@ -15,8 +15,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "xTuZ15NVXZ-D",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "xTuZ15NVXZ-D"
       },
       "source": [
         "## Loading libraries"
@@ -24,24 +24,24 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 11,
       "metadata": {
-        "id": "dnqh7YF2XRob",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "dnqh7YF2XRob"
       },
+      "outputs": [],
       "source": [
         "import numpy as np\n",
         "import pandas as pd\n",
         "import glob"
-      ],
-      "execution_count": 11,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "pOPP3a_MW8V0",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "pOPP3a_MW8V0"
       },
       "source": [
         "## Loading the datasets in Pandas\n",
@@ -51,18 +51,20 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 15,
       "metadata": {
-        "id": "1C4TnBTrUCnR",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "1C4TnBTrUCnR"
       },
+      "outputs": [],
       "source": [
         "path = './'\n",
         "documents = ['photos', 'keywords', 'collections', 'conversions', 'colors']\n",
         "datasets = {}\n",
         "\n",
         "for doc in documents:\n",
-        "  files = glob.glob(path + doc + \".tsv*\")\n",
+        "  files = glob.glob(path + doc + \".csv*\")\n",
         "\n",
         "  subsets = []\n",
         "  for filename in files:\n",
@@ -70,15 +72,13 @@
         "    subsets.append(df)\n",
         "\n",
         "  datasets[doc] = pd.concat(subsets, axis=0, ignore_index=True)"
-      ],
-      "execution_count": 15,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "hlJ3gl4BXiIq",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "hlJ3gl4BXiIq"
       },
       "source": [
         "## Exploring the datasets\n",
@@ -90,55 +90,55 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Oqsl7d1kVfeW",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "Oqsl7d1kVfeW"
       },
+      "outputs": [],
       "source": [
         "datasets['photos'].head()"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "-r3bUIlwXnJV",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "-r3bUIlwXnJV"
       },
+      "outputs": [],
       "source": [
         "datasets['keywords'].head()"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "SIVStDb1XpTL",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "SIVStDb1XpTL"
       },
+      "outputs": [],
       "source": [
         "datasets['collections'].head()"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "uDCjYhTeXq8v",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "uDCjYhTeXq8v"
       },
+      "outputs": [],
       "source": [
         "datasets['conversions'].head()"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
@@ -152,13 +152,13 @@
   ],
   "metadata": {
     "colab": {
+      "collapsed_sections": [],
       "name": "Loading Unsplash Research datasets in Pandas",
-      "provenance": [],
-      "collapsed_sections": []
+      "provenance": []
     },
     "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
+      "display_name": "Python 3",
+      "name": "python3"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
### Fix file extension glob pattern

The glob pattern used to load dataset files was incorrectly using .tsv* instead of .csv*. The files in the Unsplash Lite dataset have .csv* extensions (e.g. photos.csv000, keywords.csv000).

The structure of the downloaded unsplash-lite dataset I see:
```
unsplash-lite/
├── collections.csv000
├── colors.csv000
├── conversions.csv000
├── keywords.csv000
├── photos.csv000
├── DOCS.md
├── README.md
└── TERMS.md
```